### PR TITLE
Only show merge commits since a certain date

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -8,6 +8,7 @@ to_commit=${2:-'origin/staging'}
 base_url=${3:-$REPO_URL}
 git_directory=${4:-$LOCAL_REPO_PATH}
 project_subdirectory=${5:-''}
+since=$(git --git-dir "$git_directory" show -s --format=%ci "$from_commit")
 
 # Works on repos up to 99,999 issues / PRs. If your repo hits 100,000, change to {1,6\}
 pull_request_regex='[#][0-9]\{1,5\}'
@@ -28,7 +29,7 @@ function commit_changed_file_in_subdirectory() {
 }
 
 git --git-dir=$git_directory fetch
-git --git-dir=$git_directory log --oneline $from_commit..$to_commit |
+git --git-dir=$git_directory log --oneline $from_commit..$to_commit --since "$since" |
 grep $pull_request_regex |
 keep_merges_that_change_subdirectory |
 grep -o $pull_request_regex |


### PR DESCRIPTION
We merged two repositories. The target repository we merged into now has a lot of new commits originating from the repository we merged in. These commits have old timestamps, but because the merge took place recently they show these old commits show up in the recent git history of the target repository.

This change adds an additional time-based filter to the commits we select for opening PRs. Any commit that has a timestamp older than the `$from_commit` gets filtered out. This ensures old commits from the repository merged in will not show up in the PR list.

While I think this is reasonable solution for this use case, I'm not sure if it makes sense to keep this change permanently. In principle we'd like this script to find all commits that contributed to progress between a 'from' commit and a 'to' commit, regardless of how those commits came by their timestamps. It might be best to use this version of the script temporarily, and then go back to the original one once the old commits from the merged repo are far enough in the past to not show up in logs anymore.

If we believe we might want to use this mode more often in the future we can also make it toggleable by passing in some command line flag.