### PR TITLE
add option to copy markdown (and do other stuff good)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ To fork the repository and navigate to the folder:
     
 To run the script:
 
-    ./script.sh from_commit to_commit base_url git_directory project_subdirectory
+    ./script.sh [--markdown] from_commit to_commit base_url git_directory project_subdirectory
 
 Example:
 
     ./script.sh origin/production origin/staging https://github.com/myusername/myproject/pull/ ~/Documents/programs/myproject tooling
     
 Will open PRs that made changes to files in the `tooling/` directory of a project. The `project_subdirectory` parameter is optional, and if none is specified the script will look in the entire project rather than a specific subdirectory.
+
+**Warning: running this script may open a lot of new tabs!**
 
 If you set a `base_url` and a `git_directory`, the script will use those as defaults whenever they aren't specified. Example:
 
@@ -26,4 +28,6 @@ You can also add these directly to your `bash_profile` (or whatever profile you 
     
 The `from_commit` and `to_commit` variables default to `origin/production` and `origin/staging`, respectively.
 
-Warning: running this script may open a lot of new tabs!
+`--markdown` generates list of PRs and extra info in a markdown checklist and copies it to clipboard. This requires the [`hub`](https://github.com/github/hub) command to be installed and authenticated.
+
+* If you run this script with `--markdown` and see messages like "Requires authentication" or "github.com username: github.com password..." then you may not be authenticated. Try running `hub browse` from a cloned local repo to authenticate. ([There is not currently a dedicated `hub` authentication command](https://github.com/github/hub/issues/225), so please note that running `browse` will open a browser window to your origin repo URL on GitHub.)

--- a/script.sh
+++ b/script.sh
@@ -44,6 +44,11 @@ pr_numbers=$(
   cut -c 2-
 )
 
+if [ "$pr_numbers" == "" ]; then
+  echo "There were no PRs merged between $from_commit..$to_commit"
+  exit 0
+fi
+
 if [ "$markdown" == "true" ]; then
   echo "Generating markdown..."
   echo "$pr_numbers" |

--- a/script.sh
+++ b/script.sh
@@ -5,7 +5,7 @@ if [ "$1" == "--help" ]; then
   exit 1
 fi
 if [ "$1" == "--markdown" ]; then
-  command -v hub >/dev/null 2>&1 || { printf >&2 "To generate markdown, you need to install hub first by running:\nbrew install hub\nSee https://github.com/github/hub for more information.\n"; exit 1; }
+  command -v hub >/dev/null 2>&1 || { printf >&2 "To generate markdown, you need to install hub first by running:\nbrew install hub\nThen authenticate by navigating to any local repo folder with a remote GitHub origin and running:\nhub browse\nSee https://github.com/github/hub or this repo's README for more information.\n"; exit 1; }
   markdown="true"
   shift
 fi

--- a/script.sh
+++ b/script.sh
@@ -1,11 +1,11 @@
 # TODO: think about quote marks
-# TODO: something about installing hub
 
 if [ "$1" == "--help" ]; then
   echo "Usage: ./script.sh from_commit to_commit base_url git_directory project_subdirectory"
   exit 1
 fi
 if [ "$1" == "--markdown" ]; then
+  command -v hub >/dev/null 2>&1 || { echo >&2 "To generate markdown, you need to install hub first by running:\nbrew install hub\nSee https://github.com/github/hub for more information."; exit 1; }
   markdown="true"
   shift
 fi

--- a/script.sh
+++ b/script.sh
@@ -49,6 +49,10 @@ if [ "$pr_numbers" == "" ]; then
   exit 0
 fi
 
+echo "$pr_numbers" |
+sed -e "s|^|$base_url|" |
+xargs open
+
 if [ "$markdown" == "true" ]; then
   echo "Generating markdown..."
   echo "$pr_numbers" |
@@ -57,7 +61,3 @@ if [ "$markdown" == "true" ]; then
   pbpaste
   echo "Markdown copied to clipboard."
 fi
-
-echo "$pr_numbers" |
-sed -e "s|^|$base_url|" |
-xargs open

--- a/script.sh
+++ b/script.sh
@@ -1,11 +1,11 @@
-# TODO: think about quote marks
+#!/bin/bash
 
 if [ "$1" == "--help" ]; then
   echo "Usage: ./script.sh from_commit to_commit base_url git_directory project_subdirectory"
   exit 1
 fi
 if [ "$1" == "--markdown" ]; then
-  command -v hub >/dev/null 2>&1 || { echo >&2 "To generate markdown, you need to install hub first by running:\nbrew install hub\nSee https://github.com/github/hub for more information."; exit 1; }
+  command -v hub >/dev/null 2>&1 || { printf >&2 "To generate markdown, you need to install hub first by running:\nbrew install hub\nSee https://github.com/github/hub for more information."; exit 1; }
   markdown="true"
   shift
 fi
@@ -34,13 +34,13 @@ function commit_changed_file_in_subdirectory() {
     grep "^${project_subdirectory}"
 }
 
-git --git-dir=$git_directory fetch
+git --git-dir="$git_directory" fetch
 
 pr_numbers=$(
-  git --git-dir=$git_directory log --oneline $from_commit..$to_commit |
-  grep $pull_request_regex |
+  git --git-dir="$git_directory" log --oneline "$from_commit..$to_commit" |
+  grep "$pull_request_regex" |
   keep_merges_that_change_subdirectory |
-  grep -o $pull_request_regex |
+  grep -o "$pull_request_regex" |
   cut -c 2-
 )
 
@@ -56,7 +56,7 @@ xargs open
 if [ "$markdown" == "true" ]; then
   echo "Generating markdown..."
   echo "$pr_numbers" |
-  xargs -n 1 hub --git-dir=$LOCAL_REPO_PATH pr show -f "[ ] %i [%t](%U) (%au)" |
+  xargs -n 1 hub --git-dir="$LOCAL_REPO_PATH" pr show -f "[ ] %i [%t](%U) (%au)" |
   pbcopy
   pbpaste
   echo "Markdown copied to clipboard."

--- a/script.sh
+++ b/script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" == "--help" ]; then
-  echo "Usage: ./script.sh from_commit to_commit base_url git_directory project_subdirectory"
+  printf "Usage:\n./script.sh [--markdown] from_commit to_commit base_url git_directory project_subdirectory\n             --markdown : generates list of PRs and extra info in a markdown checklist and copies it to clipboard\n"
   exit 1
 fi
 if [ "$1" == "--markdown" ]; then

--- a/script.sh
+++ b/script.sh
@@ -5,7 +5,7 @@ if [ "$1" == "--help" ]; then
   exit 1
 fi
 if [ "$1" == "--markdown" ]; then
-  command -v hub >/dev/null 2>&1 || { printf >&2 "To generate markdown, you need to install hub first by running:\nbrew install hub\nSee https://github.com/github/hub for more information."; exit 1; }
+  command -v hub >/dev/null 2>&1 || { printf >&2 "To generate markdown, you need to install hub first by running:\nbrew install hub\nSee https://github.com/github/hub for more information.\n"; exit 1; }
   markdown="true"
   shift
 fi


### PR DESCRIPTION
🍐 'd with @leapingfrogs

Maybe reviewable commit by commit!

### Goal
Be able to use this script to optionally output the list of PRs in a nice format, esp for use in master QA. (And maybe even monorepo QA in the future?)

### Updates
* Adding `--markdown` will copy the PR list in a nice checkboxy markdown list to your clipboard and also pastes it to the terminal (just in case you overwrite your clipboard or you want to re-copy a line later)
* Added info about `--markdown` to `--help`

### Unchanged
* Just noting that this doesn't change the underlying functionality of opening the PRs - that still happens even if you opt to copy markdown

### Unrelated to the goal
* Handled case of 0 PRs / output helpful message
* Ran Shellcheck on the file
    * Cleaned up variables in quote marks
    * Declared #!/bin/bash
    * Used `printf` in some places instead of `echo`

### Knowledge share
* [Hub](https://github.com/github/hub) is a cool command
* [Shellcheck](https://github.com/koalaman/shellcheck) is a cool editor plugin
* `printf` [handles linebreaks and tabs](https://github.com/koalaman/shellcheck/wiki/SC2028)
* `shift` (in the "if markdown" section at the top) shifts the variables so the script still works even without --markdown being provided. This prevents the `markdown` variable being set as $1 and overwriting the `from_commit` variable.